### PR TITLE
Final fix for null categories when submitting an idea

### DIFF
--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/ui/PostIdeaAdapter.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/ui/PostIdeaAdapter.java
@@ -107,7 +107,11 @@ public class PostIdeaAdapter extends InstantAnswersAdapter {
 		SigninManager.signIn(context, emailField.getText().toString(), nameField.getText().toString(), new Runnable() {
 			@Override
 			public void run() {
-				Category category = (Category) categorySelect.getSelectedItem();
+				Category category = null;
+				if(categorySelect != null) {
+					category = (Category) categorySelect.getSelectedItem();
+				}
+				
 				Suggestion.createSuggestion(Session.getInstance().getForum(), category, textField.getText().toString(), descriptionField.getText().toString(), 1, new DefaultCallback<Suggestion>(context) {
 					@Override
 					public void onModel(Suggestion model) {


### PR DESCRIPTION
Fixes #24 by skipping the category check if it is null during submission of an idea.
