### PR TITLE
Update DownloadImageTask.java

### DIFF
--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/image/DownloadImageTask.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/image/DownloadImageTask.java
@@ -19,11 +19,15 @@ public class DownloadImageTask extends AsyncTask<Void, Void, Bitmap> {
 
     protected Bitmap doInBackground(Void... voids) {
         Bitmap bitmap = null;
+        InputStream in = null;
+        
         try {
-            InputStream in = new java.net.URL(url).openStream();
+            in = new java.net.URL(url).openStream();
             bitmap = BitmapFactory.decodeStream(in);
         } catch (Exception e) {
             e.printStackTrace();
+        } finally {
+            in.close();
         }
         return bitmap;
     }


### PR DESCRIPTION
Fixes a warning and a real potential leak: "Potential resource leak: 'in' may not be closed"
