### PR TITLE
Fix compile error in DownloadImageTask

### DIFF
--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/image/DownloadImageTask.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/image/DownloadImageTask.java
@@ -20,14 +20,17 @@ public class DownloadImageTask extends AsyncTask<Void, Void, Bitmap> {
     protected Bitmap doInBackground(Void... voids) {
         Bitmap bitmap = null;
         InputStream in = null;
-        
+
         try {
             in = new java.net.URL(url).openStream();
             bitmap = BitmapFactory.decodeStream(in);
         } catch (Exception e) {
             e.printStackTrace();
         } finally {
-            in.close();
+            try {
+                in.close();
+            } catch (Exception ignored) {
+            }
         }
         return bitmap;
     }


### PR DESCRIPTION
in.close() can throw an IOException which should caught
