### PR TITLE
Fix date string parsing

### DIFF
--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/model/BaseModel.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/model/BaseModel.java
@@ -5,7 +5,9 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -73,9 +75,9 @@ public class BaseModel {
     @SuppressLint("SimpleDateFormat")
     protected Date getDate(JSONObject object, String key) throws JSONException {
         String dateString = getString(object, key);
-        SimpleDateFormat format = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss Z");
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
         try {
-            return format.parse(dateString);
+            return format.parse(dateString.replaceAll("Z$", "+0000"));
         } catch (ParseException e1) {
             throw new JSONException("Could not parse date: " + dateString);
         }


### PR DESCRIPTION
SimpleDateFormat doesn't know how to parse dates containing the literal
'Z' as time zone, so we replace it with "+0000".
