### PR TITLE
Crash fix in PortalAdapter

### DIFF
--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/ui/PortalAdapter.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/ui/PortalAdapter.java
@@ -124,6 +124,8 @@ public class PortalAdapter extends SearchAdapter<BaseModel> implements AdapterVi
 
     @Override
     public int getCount() {
+    	if (Session.getInstance().getClientConfig() == null) return 0;
+    	
         if (!configLoaded) {
             return 1;
         } else {


### PR DESCRIPTION
Received this crash report: http://crashes.to/s/650ee77b70a 
Seems like `Session.getInstance().getClientConfig()` returns null and thus the app crashes (`NullPointerException`)
