### PR TITLE
Fix Session to be a real singleton

### DIFF
--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/Session.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/Session.java
@@ -22,7 +22,7 @@ public class Session {
 
     private static Session instance;
 
-    public static Session getInstance() {
+    public static synchronized Session getInstance() {
         if (instance == null) {
             instance = new Session();
         }


### PR DESCRIPTION
During UserVoice SDK initialization the main thread and another thread started in Babayaga#init (btw, what are these for?) try each to acquire a Session. The problem here is that Session#getInstance is not thread-safe and we end up creating more than one Session object.

In our application, this was leading to NullPointerExceptions in Session#getSharedPreferences because the Session instance was replaced with a new one without a context from a background thread right after Session#setContext was called from UserVoice#init.

I guess this will also fix the root cause of #152 .
