### PR TITLE
Update Utils.java

### DIFF
--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/ui/Utils.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/ui/Utils.java
@@ -32,10 +32,10 @@ public class Utils {
     public static void displayArticle(WebView webView, Article article, Context context) {
         String styles = "iframe, img { max-width: 100%; }";
         if (isDarkTheme(context)) {
-            webView.setBackgroundColor(Color.BLACK);
-            styles += "body { background-color: #000000; color: #F6F6F6; } a { color: #0099FF; }";
+            webView.setBackgroundColor(Color.parseColor("#303030"));
+            styles += "body { background-color: #303030; color: #F6F6F6; } a { color: #0099FF; }";
         }
-        String html = String.format("<html><head><meta charset=\"utf-8\"><link rel=\"stylesheet\" type=\"text/css\" href=\"http://cdn.uservoice.com/stylesheets/vendor/typeset.css\"/><style>%s</style></head><body class=\"typeset\" style=\"font-family: sans-serif; margin: 1em\"><h3>%s</h3>%s</body></html>", styles, article.getTitle(), article.getHtml());
+        String html = String.format("<html><head><meta charset=\"utf-8\"><link rel=\"stylesheet\" type=\"text/css\" href=\"http://cdn.uservoice.com/stylesheets/vendor/typeset.css\"/><style>%s</style></head><body class=\"typeset\" style=\"font-family: sans-serif; margin: 1em\"><h3>%s</h3><br>%s</body></html>", styles, article.getTitle(), article.getHtml());
         webView.setWebChromeClient(new WebChromeClient());
         webView.getSettings().setJavaScriptEnabled(true);
         webView.getSettings().setPluginState(PluginState.ON);


### PR DESCRIPTION
#424242 (android 5) / #303030 (android 4) is more gentle than black + fits in the the new dark material appCompat.

Added a space between title and content (were squished together).

Below is another mockup that changes title and positive/negative button text. Cleaner, no?

Android 5
![device-2014-12-16-215124](https://cloud.githubusercontent.com/assets/4555882/5465861/c2dc5866-856d-11e4-999b-0b1eaf32c1c8.png)

Android 4
![device-2014-12-16-221530](https://cloud.githubusercontent.com/assets/4555882/5466049/187744cc-8571-11e4-8f7d-617a475f459b.png)
