### PR TITLE
Always check that emails are valid before setting persistent identity

### DIFF
--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/Session.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/Session.java
@@ -13,6 +13,7 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 
 import com.uservoice.uservoicesdk.babayaga.Babayaga;
+import com.uservoice.uservoicesdk.flow.SigninManager;
 import com.uservoice.uservoicesdk.model.AccessToken;
 import com.uservoice.uservoicesdk.model.ClientConfig;
 import com.uservoice.uservoicesdk.model.Forum;
@@ -63,9 +64,7 @@ public class Session {
 
     public void setConfig(Config config) {
         this.config = config;
-        if (config.getEmail() != null) {
-            persistIdentity(config.getName(), config.getEmail());
-        }
+        persistIdentity(config.getName(), config.getEmail());
         config.persist(getSharedPreferences(), "config", "config");
         persistSite();
     }
@@ -77,7 +76,9 @@ public class Session {
     public void persistIdentity(String name, String email) {
         Editor edit = getSharedPreferences().edit();
         edit.putString("user_name", name);
-        edit.putString("user_email", email);
+        if (SigninManager.isValidEmail(email)) {
+            edit.putString("user_email", email);
+        }
         edit.commit();
     }
 

--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/flow/SigninManager.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/flow/SigninManager.java
@@ -2,6 +2,7 @@ package com.uservoice.uservoicesdk.flow;
 
 import android.support.v4.app.FragmentActivity;
 
+import android.text.TextUtils;
 import android.widget.Toast;
 import com.uservoice.uservoicesdk.R;
 import com.uservoice.uservoicesdk.Session;
@@ -25,7 +26,7 @@ public class SigninManager {
     private String name;
     private final FragmentActivity activity;
     private boolean passwordOnly;
-    private Pattern emailFormat = Pattern.compile("\\A(\\w[-+.\\w!\\#\\$%&'\\*\\+\\-/=\\?\\^_`\\{\\|\\}~]*@([-\\w]*\\.)+[a-zA-Z]{2,9})\\z");
+    private static Pattern emailFormat = Pattern.compile("\\A(\\w[-+.\\w!\\#\\$%&'\\*\\+\\-/=\\?\\^_`\\{\\|\\}~]*@([-\\w]*\\.)+[a-zA-Z]{2,9})\\z");
 
     public static void signIn(FragmentActivity activity, SigninCallback callback) {
         new SigninManager(activity, null, null, callback).signIn();
@@ -33,6 +34,10 @@ public class SigninManager {
 
     public static void signIn(FragmentActivity activity, String email, String name, SigninCallback callback) {
         new SigninManager(activity, email, name, callback).signIn();
+    }
+
+    public static boolean isValidEmail(String email) {
+        return !TextUtils.isEmpty(email) && emailFormat.matcher(email).matches();
     }
 
     private SigninManager(FragmentActivity activity, String email, String name, SigninCallback callback) {
@@ -49,7 +54,7 @@ public class SigninManager {
         } else if (Session.getInstance().getAccessToken() != null) {
             // If we have an access token but no user, they have signed in in this session. Don't prompt again.
             callback.onSuccess();
-        } else if (email != null && !emailFormat.matcher(email).matches()) {
+        } else if (!isValidEmail(email)) {
             Toast.makeText(activity, R.string.uv_msg_bad_email_format, Toast.LENGTH_SHORT).show();
             callback.onFailure();
         } else {

--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/ui/InstantAnswersAdapter.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/ui/InstantAnswersAdapter.java
@@ -2,7 +2,6 @@ package com.uservoice.uservoicesdk.ui;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.Context;
 import android.support.v4.app.FragmentActivity;
 import android.text.Editable;
@@ -20,10 +19,12 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.uservoice.uservoicesdk.R;
 import com.uservoice.uservoicesdk.Session;
 import com.uservoice.uservoicesdk.deflection.Deflection;
+import com.uservoice.uservoicesdk.flow.SigninManager;
 import com.uservoice.uservoicesdk.model.Article;
 import com.uservoice.uservoicesdk.model.BaseModel;
 import com.uservoice.uservoicesdk.model.Suggestion;
@@ -298,11 +299,8 @@ public abstract class InstantAnswersAdapter extends BaseAdapter implements ViewG
         } else if (state == State.DETAILS) {
             String name = nameField.getText().toString();
             String email = emailField.getText().toString();
-            if (email.length() == 0) {
-                AlertDialog.Builder builder = new AlertDialog.Builder(context);
-                builder.setTitle(R.string.uv_error);
-                builder.setMessage(R.string.uv_msg_user_identity_validation);
-                builder.create().show();
+            if (!SigninManager.isValidEmail(email)) {
+                Toast.makeText(context, R.string.uv_msg_bad_email_format, Toast.LENGTH_SHORT).show();
             } else if (!isPosting) {
                 isPosting = true;
                 Session.getInstance().persistIdentity(name, email);


### PR DESCRIPTION
There are a few places where there is no null/invalid check for the email address. As a result, it is possible to incorrectly set the persistent identity's email address, which would in turn prevent actions such as "I want this!".

For example:
1. Enter "Post an idea" flow
2. Search for an existing idea
3. Tap an existing idea
4. Tap the "I want this!" button
5. Leave email address blank in the dialog and tap "Subscribe"
The dialog will close but you will be unable to subscribe due to an invalid email address. Instead a "There was an error connecting to UserVoice" popup will show. From here, the user will not be able to perform any actions requiring an email address unless they clear the app's settings/reinstall.

This pull request's change prevents this by always checking that the email address is not null and matches the email pattern. In the example's case, a Toast with an error message will appear instead of closing the dialog.
For additional information, please contact Philip Peng (phpeng @ microsoft.com)