### PR TITLE
Remove unneeded resource name which conflicts with other libraries

### DIFF
--- a/UserVoiceSDK/res/values-sw720dp-land/dimens.xml
+++ b/UserVoiceSDK/res/values-sw720dp-land/dimens.xml
@@ -4,6 +4,5 @@
          Customize dimensions originally defined in res/values/dimens.xml (such as
          screen margins) for sw720dp devices (e.g. 10" tablets) in landscape here.
     -->
-    <dimen name="activity_horizontal_margin">128dp</dimen>
 
 </resources>


### PR DESCRIPTION
Using the latest Gradle tools, we are currently unable to consume the UserVoice SDK because the activity_horizontal_margin resource in dimens.xml conflicts with another library containing the same resource name. The name conflict is likely due to this being a default resource created by Eclipse. After removing this resource and rebuilding the SDK locally, we were able to compile our app again. Given that activity_horizontal_margin does not seem to be used anywhere in the SDK, the pull request is to remove the resource altogether.