### PR TITLE
Fix an NPE in getDetailRows in PostIdeaAdapter

### DIFF
--- a/UVDemo/build.gradle
+++ b/UVDemo/build.gradle
@@ -2,6 +2,10 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 
     dependencies {
@@ -14,6 +18,10 @@ apply plugin: 'com.android.application'
 repositories {
     mavenCentral()
     google()
+    maven {
+        url 'https://maven.google.com/'
+        name 'Google'
+    }
 }
 
 android {

--- a/UVDemo/build.gradle
+++ b/UVDemo/build.gradle
@@ -1,32 +1,31 @@
 buildscript {
     repositories {
-        mavenCentral()
         jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 
 apply plugin: 'com.android.application'
 
 repositories {
-    mavenCentral()
-    google()
     maven {
         url 'https://maven.google.com/'
         name 'Google'
     }
+    mavenCentral()
+    google()
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 28
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
@@ -77,6 +76,6 @@ tasks.whenTaskAdded { theTask ->
 }
 
 dependencies {
-    compile 'com.android.support:support-core-utils:26.1.0'
-    compile project(':UserVoiceSDK')
+    implementation 'com.android.support:support-core-utils:28.0.0'
+    implementation project(':UserVoiceSDK')
 }

--- a/UserVoiceSDK/build.gradle
+++ b/UserVoiceSDK/build.gradle
@@ -2,6 +2,10 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 
     dependencies {

--- a/UserVoiceSDK/build.gradle
+++ b/UserVoiceSDK/build.gradle
@@ -1,15 +1,15 @@
 buildscript {
     repositories {
-        mavenCentral()
         jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 
@@ -21,7 +21,7 @@ uploadArchives {
     repositories.mavenDeployer {
         pom.groupId = 'com.uservoice'
         pom.artifactId = 'uservoice-android-sdk'
-        pom.version = '1.2.7'
+        pom.version = '1.2.8'
         // Add other pom properties here if you want (developer details / licenses)
         repository(url: "file:///Users/austin/tmp/")
     }
@@ -41,8 +41,7 @@ repositories {
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 28
 
     sourceSets {
         main {
@@ -55,9 +54,8 @@ android {
 }
 
 dependencies {
-    // compile 'com.android.support:support-v4:21.+'
-    compile 'com.android.support:support-core-utils:26.1.0'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.squareup.okhttp3:okhttp:3.10.0'
-    compile 'oauth.signpost:signpost-core:1.2.1.2'
+    implementation 'com.android.support:support-core-utils:28.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.11.0'
+    implementation 'oauth.signpost:signpost-core:1.2.1.2'
 }

--- a/UserVoiceSDK/src/com/uservoice/uservoicesdk/ui/PostIdeaAdapter.java
+++ b/UserVoiceSDK/src/com/uservoice/uservoicesdk/ui/PostIdeaAdapter.java
@@ -49,8 +49,15 @@ public class PostIdeaAdapter extends InstantAnswersAdapter {
     protected List<Integer> getDetailRows() {
         List<Integer> rows = new ArrayList<Integer>();
         rows.add(DESCRIPTION);
-        if (Session.getInstance().getForum().getCategories().size() > 0)
+
+        // The data for the forum, and categories is asynchronous and may not have
+        // been loaded yet, so be careful and only show the CATEGORY row if the data
+        // is available.
+        if (Session.getInstance().getForum() != null &&
+                Session.getInstance().getForum().getCategories() != null &&
+                Session.getInstance().getForum().getCategories().size() > 0)
             rows.add(CATEGORY);
+
         rows.add(SPACE);
         rows.add(EMAIL_FIELD);
         rows.add(NAME_FIELD);
@@ -105,7 +112,7 @@ public class PostIdeaAdapter extends InstantAnswersAdapter {
             EditText textView = (EditText) view.findViewById(R.id.uv_text);
             textView.setHint(R.string.uv_idea_text_hint);
             textView.setMinLines(1);
-            textView.setFilters(new InputFilter[] { new InputFilter.LengthFilter(140) });
+            textView.setFilters(new InputFilter[]{new InputFilter.LengthFilter(140)});
         } else {
             return super.getView(position, view, parent);
         }

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,18 @@ allprojects {
         maven {
             url "https://maven.google.com"
         }
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 buildscript {
     repositories {
         google()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 allprojects {
     repositories {
+        jcenter()
         maven {
             url "https://maven.google.com"
         }
@@ -13,6 +14,7 @@ allprojects {
 buildscript {
     repositories {
         google()
+        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'


### PR DESCRIPTION
We were seeing the following crash:

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.List com.uservoice.uservoicesdk.model.Forum.getCategories()' on a null object reference
       at com.uservoice.uservoicesdk.ui.PostIdeaAdapter.getDetailRows(PostIdeaAdapter.java:52)
       at com.uservoice.uservoicesdk.ui.InstantAnswersAdapter.getRows(InstantAnswersAdapter.java:94)
       at com.uservoice.uservoicesdk.ui.PostIdeaAdapter.getRows(PostIdeaAdapter.java:62)
       at com.uservoice.uservoicesdk.ui.InstantAnswersAdapter.getCount(InstantAnswersAdapter.java:106)
       at android.widget.AdapterView$AdapterDataSetObserver.onChanged(AdapterView.java:836)
       at android.widget.AbsListView$AdapterDataSetObserver.onChanged(AbsListView.java:6421)
       at android.database.DataSetObservable.notifyChanged(DataSetObservable.java:37)
       at android.widget.BaseAdapter.notifyDataSetChanged(BaseAdapter.java:52)
       at com.uservoice.uservoicesdk.ui.InstantAnswersAdapter.onButtonTapped(InstantAnswersAdapter.java:298)
       at com.uservoice.uservoicesdk.ui.InstantAnswersAdapter$1.onClick(InstantAnswersAdapter.java:163)
       at android.view.View.performClick(View.java:6597)
       at android.view.View.performClickInternal(View.java:6574)
       at android.view.View.access$3100(View.java:778)
       at android.view.View$PerformClick.run(View.java:25885)
       at android.os.Handler.handleCallback(Handler.java:873)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:193)
       at android.app.ActivityThread.main(ActivityThread.java:6669)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```
This PR is a patch only, to avoid this particular crash. Unfortunately due to the async nature of the design of this SDK it's possible to have crashes in a number of different places where the data has not yet loaded. So, it's not a long-term solution.

The remainder of the changes were in order to make the library build on jitpack which was used to test the deployment. It updates to the newest Android API and recent support library. (pre AndroidX)